### PR TITLE
Can now request content keys for crypto periods and separate tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ There are two public APIs in the server: get\_content\_key() and get_license().
 ## Get Content Key
 This API is typically used by the SYE Ingress in order to get encryption keys for a channel.
 
-It is possible to request keys for one or many crypto periods (two in the example below)
+It is possible to request keys for one or many crypto periods (two in the example below).
 
-It is possible to request keys for one or many track types (two in the example below)
+It is possible to request keys for one or many track types (two in the example below).
+
+get\_content\_key is guaranteed to always return the same kid and key for a specific combination of contentId, cryptoPeriod and track type.
 
 ### Request
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,22 @@ There are two public APIs in the server: get\_content\_key() and get_license().
 ## Get Content Key
 This API is typically used by the SYE Ingress in order to get encryption keys for a channel.
 
+It is possible to request keys for one or many crypto periods (two in the example below)
+
+It is possible to request keys for one or many track types (two in the example below)
+
 ### Request
 
 ```
 {
-    "contentId": "svt1"
+    "contentId": "svt1",
+    "cryptoPeriodIndex": 424214,
+    "cryptoPeriodCount": 2,
+    "tracks": [{
+        "type": "SD"
+    }, {
+        "type": "4K"
+    }]
 }
 ```
 
@@ -32,19 +43,70 @@ This API is typically used by the SYE Ingress in order to get encryption keys fo
 ```
 {
     "contentId": "svt1",
-    "ttlSeconds": 44,
-    "kid": "NGEyZTY2MmYzNTQ3YTNhZQ==",
-    "key": "OTExY2I4NTFjODk3ZDg1NA==",
-    "drm": [{
-        "systemID": "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b",
-        "pssh": "AAAAVHBzc2gBAAAAEHfv7MCyTQKs4zweUuL7SwAAAAM4NjJlYTgxYmMxOTczYjhlNGEyZTY2MmYzNTQ3YTNhZTE1YjJlZTMzMjMyYzU3YWYAAAAA"
+    "cryptoPeriods": [{
+        "cryptoPeriod": 424214,
+        "tracks": [{
+            "type": "SD",
+            "kid": "MTIzNDU2NzgxMjM0NTY3OAo",
+            "key": "YmNkNjM4NTA5MTI3ODM3Ngo",
+            "pssh": [{
+                "systemId": "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b",
+                "pssh": "aDM0aDM0MjNrMDAyODVtb"
+            },
+            {
+                "systemId": "edef8ba979d64acea3c827dcd51d21ed",
+                "pssh": "nZzMyNDM0MmRmYWRm"
+            }]
+        },
+        {
+            "type": "4K",
+            "kid": "MTIzNDU2NzgxMjM0NTY3OAo",
+            "key": "YmNkNjM4NTA5MTI3ODM3Ngo",
+            "pssh": [{
+                "systemId": "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b",
+                "pssh": "aDM0aDM0MjNrMDAyODVtb"
+            },
+            {
+                "systemId": "edef8ba979d64acea3c827dcd51d21ed",
+                "pssh": "nZzMyNDM0MmRmYWRm"
+            }]
+        }]
+    },
+    {
+        "cryptoPeriod": 424215,
+        "tracks": [{
+            "type": "SD",
+            "kid": "MTIzNDU2NzgxMjM0NTY3OAo",
+            "key": "YmNkNjM4NTA5MTI3ODM3Ngo",
+            "pssh": [{
+                "systemId": "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b",
+                "pssh": "aDM0aDM0MjNrMDAyODVtb"
+            },
+            {
+                "systemId": "edef8ba979d64acea3c827dcd51d21ed",
+                "pssh": "nZzMyNDM0MmRmYWRm"
+            }]
+        },
+        {
+            "type": "SD",
+            "kid": "MTIzNDU2NzgxMjM0NTY3OAo",
+            "key": "YmNkNjM4NTA5MTI3ODM3Ngo",
+            "pssh": [{
+                "systemId": "1077efec-c0b2-4d02-ace3-3c1e52e2fb4b",
+                "pssh": "aDM0aDM0MjNrMDAyODVtb"
+            },
+            {
+                "systemId": "edef8ba979d64acea3c827dcd51d21ed",
+                "pssh": "nZzMyNDM0MmRmYWRm"
+            }]
+        }]
     }]
 }
 ```
 
 ### cURL example
 
-    curl -i -d '{"contentId": "svt1"}' -H "Content-Type: application/json" http://localhost:8000/get_content_key
+    curl -i -d '{"contentId":"svt1","cryptoPeriodIndex":10,"cryptoPeriodCount":2,"tracks":[{"type": "SD"},{"type":"4K"}]}' -H "Content-Type: application/json" http://localhost:8000/get_content_key
 
 ## Get License 
 This API is typically used by a CDM within a client application and follow w3.org example: https://www.w3.org/TR/encrypted-media/

--- a/index.js
+++ b/index.js
@@ -5,17 +5,28 @@ const clearkey = require('./clearkey')
 
 const app = express();
 app.use(bodyParser.json());
+app.set('json spaces', 2);
 
 app.post('/get_content_key', (req, res) => {
     let request = req.body;
-    let response = clearkey.getContentKey(request);
-    res.json(response);
+    try {
+        let response = clearkey.getContentKey(request);
+        res.json(response);
+    }
+    catch (e) {
+        res.status(400).send({ error: e });
+    }
 })
 
 app.post('/get_license', (req, res) => {
     let request = req.body;
-    let response = clearkey.getLicense(request);
-    res.json(response);
+    try {
+        let response = clearkey.getLicense(request);
+        res.json(response);
+    }
+    catch (e) {
+        res.status(400).send({ error: e });
+    }
 })
 
 app.listen(8000, () => {


### PR DESCRIPTION
Two new features:

1. Can now request content keys for one or many crypto periods. This is good since we can then ask for kid+pssh for future key periods which means we can pre-fetch licenses in the client.

2. Can now request content keys for one or many track types. E.g. encrypt SD content with one key and HD content with another key.